### PR TITLE
fix: remove readiness file, use Extensions API INIT ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,33 +158,9 @@ aws lambda publish-layer-version \
 
 ### 3. Add the layer and environment variable
 
-Add the layer ARN to your function and set `CIRCUITBREAKER_TABLE`.
+Add the layer ARN to your function and set `CIRCUITBREAKER_TABLE`. The extension binds its HTTP server and registers with the Lambda Extensions API during INIT -- Lambda won't invoke your handler until the extension is ready.
 
-### 4. Wait for readiness on cold start
-
-The extension writes `/tmp/.circuitbreaker-lambda-ready` when its HTTP server is ready. On cold starts, your handler may run before the extension has bound its port. Check for this file before making the first HTTP call:
-
-```js
-// Node.js — poll up to 5 seconds (100 × 50ms)
-import { existsSync } from "node:fs";
-for (let i = 0; i < 100; i++) {
-  if (existsSync("/tmp/.circuitbreaker-lambda-ready")) break;
-  await new Promise((r) => setTimeout(r, 50));
-}
-```
-
-```python
-# Python — poll up to 5 seconds (100 × 50ms)
-import os, time
-for _ in range(100):
-    if os.path.exists("/tmp/.circuitbreaker-lambda-ready"):
-        break
-    time.sleep(0.05)
-```
-
-This only needs to run once per cold start. See the `examples/layer/` directory for complete examples.
-
-### 5. Call the local HTTP API from your function
+### 4. Call the local HTTP API from your function
 
 The extension listens on `http://127.0.0.1:4243` (configurable via `CIRCUITBREAKER_PORT`).
 
@@ -241,7 +217,7 @@ The layer works with all supported Lambda runtimes:
 
 Both x86_64 and arm64 architectures are supported.
 
-> **Memory and cold starts:** Lambda allocates CPU proportionally to memory. At the default 128MB, the extension's cold start (AWS SDK initialization, TLS handshake, credential resolution) is CPU-starved and adds several seconds. At 512MB+, the extension cold start overhead drops to ~400ms and warm invocation overhead is under 10ms. This applies to both the npm package and the layer, but is more pronounced with the layer since it runs a separate process.
+> **Memory and cold starts:** Lambda allocates CPU proportionally to memory. At the default 128MB, cold starts are CPU-starved (AWS SDK initialization, TLS handshake, credential resolution). At 512MB, the layer adds ~350ms to cold start and warm invocations have near-zero overhead. The npm package adds ~50ms to cold start at 512MB. Both paths benefit from higher memory settings.
 
 ## Circuit Breaker States
 

--- a/examples/layer/node/index.mjs
+++ b/examples/layer/node/index.mjs
@@ -1,4 +1,3 @@
-import { existsSync } from "node:fs";
 import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import { DynamoDBDocumentClient, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
 
@@ -8,15 +7,6 @@ const CONTROL_KEY = "_downstream_healthy";
 const CIRCUITBREAKER_PORT = process.env.CIRCUITBREAKER_PORT || "4243";
 const CIRCUITBREAKER_URL = `http://127.0.0.1:${CIRCUITBREAKER_PORT}`;
 const CIRCUIT_ID = process.env.AWS_LAMBDA_FUNCTION_NAME || "default";
-
-let extensionReady = false;
-
-async function waitForExtension() {
-  for (let i = 0; i < 100; i++) {
-    if (existsSync("/tmp/.circuitbreaker-lambda-ready")) return;
-    await new Promise((r) => setTimeout(r, 50));
-  }
-}
 
 async function callDownstream() {
   const result = await ddb.send(
@@ -29,11 +19,6 @@ async function callDownstream() {
 }
 
 export const handler = async (event) => {
-  if (!extensionReady) {
-    await waitForExtension();
-    extensionReady = true;
-  }
-
   const method = event.requestContext?.http?.method ?? "GET";
   const path = event.rawPath ?? "/";
 

--- a/examples/layer/python/app.py
+++ b/examples/layer/python/app.py
@@ -1,6 +1,5 @@
 import json
 import os
-import time
 import urllib.request
 
 import boto3
@@ -13,15 +12,6 @@ CIRCUITBREAKER_PORT = os.environ.get("CIRCUITBREAKER_PORT", "4243")
 CIRCUITBREAKER_URL = f"http://127.0.0.1:{CIRCUITBREAKER_PORT}"
 CIRCUIT_ID = os.environ.get("AWS_LAMBDA_FUNCTION_NAME", "default")
 
-extension_ready = False
-
-
-def wait_for_extension():
-    for _ in range(100):
-        if os.path.exists("/tmp/.circuitbreaker-lambda-ready"):
-            return
-        time.sleep(0.05)
-
 
 def call_downstream():
     result = table.get_item(Key={"id": CONTROL_KEY})
@@ -31,11 +21,6 @@ def call_downstream():
 
 
 def handler(event, context):
-    global extension_ready
-    if not extension_ready:
-        wait_for_extension()
-        extension_ready = True
-
     method = event.get("requestContext", {}).get("http", {}).get("method", "GET")
     path = event.get("rawPath", "/")
 

--- a/layer/extension/src/main.rs
+++ b/layer/extension/src/main.rs
@@ -60,13 +60,15 @@ async fn main() {
 
     let has_runtime_api = env::var("AWS_LAMBDA_RUNTIME_API").is_ok();
 
-    // Register as a Lambda Extension
-    let register_handle = tokio::spawn(register_extension());
+    // Start the HTTP server and wait for it to bind before registering.
+    // Lambda won't invoke the function until registration completes, so by
+    // sequencing server bind -> register, the server is guaranteed to be
+    // ready when the handler runs. No readiness file needed.
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<()>();
 
-    // Start HTTP server (blocks forever)
     let server_manager = Arc::clone(&manager);
-    let server_handle = tokio::spawn(async move {
-        if let Err(e) = server::start_server(port, server_manager).await {
+    tokio::spawn(async move {
+        if let Err(e) = server::start_server(port, server_manager, ready_tx).await {
             error!(
                 source = "circuitbreaker-lambda",
                 action = "server",
@@ -76,9 +78,19 @@ async fn main() {
         }
     });
 
-    // Wait for extension registration, then enter event loop
-    match register_handle.await {
-        Ok(Ok(ext_id)) => {
+    // Wait for the server to bind
+    if ready_rx.await.is_err() {
+        error!(
+            source = "circuitbreaker-lambda",
+            action = "startup",
+            message = "server failed to start",
+        );
+        std::process::exit(1);
+    }
+
+    // Now register — Lambda will hold INIT until this completes
+    match register_extension().await {
+        Ok(ext_id) => {
             info!(
                 source = "circuitbreaker-lambda",
                 action = "registered",
@@ -86,12 +98,12 @@ async fn main() {
             );
             extension_event_loop(&ext_id).await;
         }
-        _ => {
+        Err(e) => {
             if has_runtime_api {
                 error!(
                     source = "circuitbreaker-lambda",
                     action = "startup",
-                    message = "extension registration failed — Lambda may freeze this process unexpectedly",
+                    message = format!("extension registration failed: {e}"),
                 );
             } else {
                 info!(
@@ -99,8 +111,9 @@ async fn main() {
                     action = "startup",
                     message = "AWS_LAMBDA_RUNTIME_API not set — running as standalone server",
                 );
+                // Keep running for local development
+                std::future::pending::<()>().await;
             }
-            let _ = server_handle.await;
         }
     }
 }
@@ -140,8 +153,6 @@ async fn extension_event_loop(ext_id: &str) {
     };
     let url = format!("http://{runtime_api}/2020-01-01/extension/event/next");
 
-    // No timeout — the Extensions API long-polls and Lambda freezes the process
-    // between invocations. A timeout would cause spurious errors.
     let client = reqwest::Client::builder()
         .no_proxy()
         .build()
@@ -158,8 +169,6 @@ async fn extension_event_loop(ext_id: &str) {
             Ok(resp) => {
                 let status = resp.status();
                 if !status.is_success() {
-                    // 404/410 = extension deregistered, unrecoverable.
-                    // Other non-2xx = transient, log and retry.
                     if status.as_u16() == 404 || status.as_u16() == 410 {
                         error!(
                             source = "circuitbreaker-lambda",

--- a/layer/extension/src/server.rs
+++ b/layer/extension/src/server.rs
@@ -8,6 +8,7 @@ use hyper::service::service_fn;
 use hyper::{Method, Request, Response, StatusCode};
 use hyper_util::rt::TokioIo;
 use tokio::net::TcpListener;
+use tokio::sync::oneshot;
 use tracing::{info, error};
 
 use crate::circuit::CircuitManager;
@@ -15,7 +16,12 @@ use crate::circuit::CircuitManager;
 /// Maximum allowed length for a circuit ID (DynamoDB partition key limit is 2048 bytes).
 const MAX_CIRCUIT_ID_LEN: usize = 256;
 
-pub async fn start_server(port: u16, manager: Arc<CircuitManager>) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+/// Start the HTTP server. Sends `()` on `ready_tx` once the TCP listener is bound.
+pub async fn start_server(
+    port: u16,
+    manager: Arc<CircuitManager>,
+    ready_tx: oneshot::Sender<()>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let addr = format!("127.0.0.1:{port}");
     let listener = TcpListener::bind(&addr).await?;
 
@@ -25,8 +31,8 @@ pub async fn start_server(port: u16, manager: Arc<CircuitManager>) -> Result<(),
         message = format!("listening on {addr}"),
     );
 
-    // Signal readiness
-    tokio::fs::write("/tmp/.circuitbreaker-lambda-ready", "").await?;
+    // Signal that the server is bound and accepting connections.
+    let _ = ready_tx.send(());
 
     loop {
         let (stream, _) = listener.accept().await?;


### PR DESCRIPTION
## Summary

- Extension now binds the HTTP server **before** registering with the Extensions API
- Lambda holds INIT until registration completes, so the server is guaranteed ready when the handler runs
- Eliminates `/tmp/.circuitbreaker-lambda-ready` and all readiness polling from user code
- Simpler examples -- no file polling, no wait functions, no ready flags
- Updated cold start numbers in README based on latest benchmarks

## Test plan
- [x] Rust compiles clean
- [x] 57 Node.js tests pass
- [x] Deployed and integration tested on AWS -- all 24 assertions pass
- [x] Full lifecycle verified for all three patterns (npm, layer+Node.js, layer+Python)
- [x] Cold start and warm latency benchmarked -- no readiness-related failures