### PR TITLE
chore: add minimal examples with real API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,13 @@ To build the layer from source instead of downloading, see `layer/build.sh`.
 
 Same workflow as above, with Node.js endpoints at `/node`, `/node/status`, `/node/toggle` and Python at `/python`, `/python/status`, `/python/toggle`.
 
+### Minimal Examples
+
+If you just want to see the bare minimum code, without the toggle/status test infrastructure:
+
+- `examples/minimal-npm/` — npm package protecting a real API call (22 lines of handler code)
+- `examples/minimal-layer/` — Lambda Layer protecting the same API call (25 lines of handler code)
+
 ## Acknowledgments
 
 Inspired by Michael Nygard's book [Release It!](https://www.amazon.com/gp/product/0978739213), Martin Fowler's article on the [circuit breaker](https://martinfowler.com/bliki/CircuitBreaker.html), and Mark Michon's post on [building a Node.js circuit breaker](https://blog.bearer.sh/build-a-circuit-breaker-in-node-js/).

--- a/examples/minimal-layer/index.mjs
+++ b/examples/minimal-layer/index.mjs
@@ -1,0 +1,25 @@
+const BREAKER = `http://127.0.0.1:${process.env.CIRCUITBREAKER_PORT || "4243"}`;
+const CIRCUIT_ID = process.env.AWS_LAMBDA_FUNCTION_NAME || "default";
+
+export const handler = async () => {
+  // 1. Check circuit
+  const { allowed } = await fetch(`${BREAKER}/circuit/${CIRCUIT_ID}`).then(r => r.json());
+  if (!allowed) {
+    return { statusCode: 503, body: JSON.stringify({ error: "Circuit OPEN" }) };
+  }
+
+  // 2. Call downstream
+  try {
+    const resp = await fetch("https://official-joke-api.appspot.com/random_joke");
+    if (!resp.ok) throw new Error(`Joke API returned ${resp.status}`);
+    const joke = await resp.json();
+
+    // 3. Record success
+    await fetch(`${BREAKER}/circuit/${CIRCUIT_ID}/success`, { method: "POST" });
+    return { statusCode: 200, body: JSON.stringify(joke) };
+  } catch (err) {
+    // 3. Record failure
+    await fetch(`${BREAKER}/circuit/${CIRCUIT_ID}/failure`, { method: "POST" });
+    return { statusCode: 503, body: JSON.stringify({ error: err.message }) };
+  }
+};

--- a/examples/minimal-layer/template.yaml
+++ b/examples/minimal-layer/template.yaml
@@ -1,0 +1,51 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+
+Parameters:
+  CircuitBreakerLayerArn:
+    Type: String
+    Description: ARN of the circuitbreaker-lambda layer (from aws lambda publish-layer-version)
+
+Resources:
+  CircuitBreakerTable:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: Delete
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+
+  JokeFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs24.x
+      Timeout: 10
+      MemorySize: 512
+      CodeUri: .
+      Layers:
+        - !Ref CircuitBreakerLayerArn
+      Environment:
+        Variables:
+          CIRCUITBREAKER_TABLE: !Ref CircuitBreakerTable
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:GetItem
+                - dynamodb:UpdateItem
+              Resource: !GetAtt CircuitBreakerTable.Arn
+      Events:
+        Api:
+          Type: HttpApi
+          Properties:
+            Path: /
+            Method: get
+
+Outputs:
+  Endpoint:
+    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.amazonaws.com"

--- a/examples/minimal-npm/index.mjs
+++ b/examples/minimal-npm/index.mjs
@@ -1,0 +1,22 @@
+import { CircuitBreaker } from "circuitbreaker-lambda";
+
+const breaker = new CircuitBreaker(fetchJoke, {
+  failureThreshold: 3,
+  successThreshold: 2,
+  timeout: 10000,
+});
+
+export const handler = async () => {
+  try {
+    const joke = await breaker.fire();
+    return { statusCode: 200, body: JSON.stringify(joke) };
+  } catch (err) {
+    return { statusCode: 503, body: JSON.stringify({ error: err.message }) };
+  }
+};
+
+async function fetchJoke() {
+  const resp = await fetch("https://official-joke-api.appspot.com/random_joke");
+  if (!resp.ok) throw new Error(`Joke API returned ${resp.status}`);
+  return resp.json();
+}

--- a/examples/minimal-npm/package.json
+++ b/examples/minimal-npm/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "minimal-npm-example",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "circuitbreaker-lambda": "^1.0.0"
+  }
+}

--- a/examples/minimal-npm/template.yaml
+++ b/examples/minimal-npm/template.yaml
@@ -1,0 +1,44 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+
+Resources:
+  CircuitBreakerTable:
+    Type: AWS::DynamoDB::Table
+    DeletionPolicy: Delete
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      BillingMode: PAY_PER_REQUEST
+
+  JokeFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: index.handler
+      Runtime: nodejs24.x
+      Timeout: 10
+      MemorySize: 512
+      CodeUri: .
+      Environment:
+        Variables:
+          CIRCUITBREAKER_TABLE: !Ref CircuitBreakerTable
+      Policies:
+        - Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:GetItem
+                - dynamodb:UpdateItem
+              Resource: !GetAtt CircuitBreakerTable.Arn
+      Events:
+        Api:
+          Type: HttpApi
+          Properties:
+            Path: /
+            Method: get
+
+Outputs:
+  Endpoint:
+    Value: !Sub "https://${ServerlessHttpApi}.execute-api.${AWS::Region}.amazonaws.com"


### PR DESCRIPTION
## Summary

Bare minimum examples showing circuitbreaker-lambda protecting a real public API call. No toggle/status test infrastructure — just a Lambda function, a circuit breaker, and a downstream HTTP call.

- `examples/minimal-npm/` — 22-line handler using the npm package
- `examples/minimal-layer/` — 25-line handler using the Lambda Layer
- README updated to reference the minimal examples