### PR TITLE
feat: rename HALF state to HALF-OPEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ graph LR
 
   subgraph Lambda["AWS Lambda"]
     Handler --> CB["Circuit Breaker"]
-    CB -- "CLOSED / HALF" --> Downstream["Downstream
+    CB -- "CLOSED / HALF-OPEN" --> Downstream["Downstream
     service"]
     CB -- "OPEN" --> Fallback["Fallback
     function"]
@@ -225,14 +225,14 @@ Both x86_64 and arm64 architectures are supported.
 | --- | --- |
 | `CLOSED` | Normal operation. All calls pass through. |
 | `OPEN` | Requests fail immediately (or use fallback). Timeout uses exponential backoff. |
-| `HALF` | A single probe request passes through. One failure immediately reopens. |
+| `HALF-OPEN` | A single probe request passes through. One failure immediately reopens. |
 
 ### State Transitions
 
 - **CLOSED -> OPEN**: `failureCount >= failureThreshold` (within `windowDuration`)
-- **OPEN -> HALF**: Timeout expires (`nextAttempt <= Date.now()`)
-- **HALF -> OPEN**: Any single failure (with exponential backoff on timeout)
-- **HALF -> CLOSED**: `successCount >= successThreshold`
+- **OPEN -> HALF-OPEN**: Timeout expires (`nextAttempt <= Date.now()`)
+- **HALF-OPEN -> OPEN**: Any single failure (with exponential backoff on timeout)
+- **HALF-OPEN -> CLOSED**: `successCount >= successThreshold`
 
 ## Configuration
 
@@ -241,7 +241,7 @@ Both the npm package and Lambda Layer support the same circuit breaker settings.
 | Setting | npm option | Layer env var | Default | Description |
 | --- | --- | --- | --- | --- |
 | Failure threshold | `failureThreshold` | `CIRCUITBREAKER_FAILURE_THRESHOLD` | `5` | Failed attempts before circuit opens |
-| Success threshold | `successThreshold` | `CIRCUITBREAKER_SUCCESS_THRESHOLD` | `2` | Successful attempts in HALF before closing |
+| Success threshold | `successThreshold` | `CIRCUITBREAKER_SUCCESS_THRESHOLD` | `2` | Successful attempts in HALF-OPEN before closing |
 | Timeout | `timeout` | `CIRCUITBREAKER_TIMEOUT_MS` | `10000` | Initial OPEN duration in ms |
 | Max timeout | `maxTimeout` | `CIRCUITBREAKER_MAX_TIMEOUT_MS` | `60000` | Max exponential backoff cap in ms |
 | Window duration | `windowDuration` | `CIRCUITBREAKER_WINDOW_DURATION_MS` | `60000` | Failure count reset window in ms |
@@ -269,7 +269,7 @@ Both the npm package and Lambda Layer support the same circuit breaker settings.
 | `CIRCUITBREAKER_TABLE` | Both | DynamoDB table name |
 | `CIRCUITBREAKER_PORT` | Layer | HTTP server port (default: `4243`) |
 | `CIRCUITBREAKER_FAILURE_THRESHOLD` | Layer | Failures before circuit opens (default: `5`) |
-| `CIRCUITBREAKER_SUCCESS_THRESHOLD` | Layer | Successes in HALF before closing (default: `2`) |
+| `CIRCUITBREAKER_SUCCESS_THRESHOLD` | Layer | Successes in HALF-OPEN before closing (default: `2`) |
 | `CIRCUITBREAKER_TIMEOUT_MS` | Layer | Initial OPEN timeout in ms (default: `10000`) |
 | `CIRCUITBREAKER_MAX_TIMEOUT_MS` | Layer | Max exponential backoff cap (default: `60000`) |
 | `CIRCUITBREAKER_WINDOW_DURATION_MS` | Layer | Failure count reset window (default: `60000`) |
@@ -291,7 +291,7 @@ All provider errors are logged as structured JSON warnings:
 
 Circuit breaker state in DynamoDB uses unconditional writes (last writer wins). This means concurrent Lambda instances can race when updating state:
 
-- **HALF state probe races:** If two instances both read HALF state and succeed, each increments `successCount` against its own in-memory copy. The second write overwrites the first, potentially delaying the CLOSED transition.
+- **HALF-OPEN state probe races:** If two instances both read HALF-OPEN state and succeed, each increments `successCount` against its own in-memory copy. The second write overwrites the first, potentially delaying the CLOSED transition.
 - **Failure count races:** Two instances both reading `failureCount: 4` and failing will both write `failureCount: 5` and open the circuit. This is safe (idempotent).
 
 In practice, these races are benign -- the circuit may be slightly slower to close than expected, but it will never miss an open. For stricter guarantees, implement a custom `StateProvider` with DynamoDB conditional writes or transactions.
@@ -303,12 +303,12 @@ State records use the following schema, shared between the npm package and the L
 | Field | Type | Description |
 | --- | --- | --- |
 | `id` | `string` | Partition key (circuit identifier) |
-| `circuitState` | `string` | `CLOSED`, `OPEN`, or `HALF` |
+| `circuitState` | `string` | `CLOSED`, `OPEN`, or `HALF-OPEN` |
 | `failureCount` | `number` | Current failure count |
-| `successCount` | `number` | Current success count (in HALF state) |
-| `nextAttempt` | `number` | Epoch ms when OPEN circuit transitions to HALF |
+| `successCount` | `number` | Current success count (in HALF-OPEN state) |
+| `nextAttempt` | `number` | Epoch ms when OPEN circuit transitions to HALF-OPEN |
 | `lastFailureTime` | `number` | Epoch ms of last failure (for window-based reset) |
-| `consecutiveOpens` | `number` | Consecutive HALF->OPEN transitions (for exponential backoff) |
+| `consecutiveOpens` | `number` | Consecutive HALF-OPEN->OPEN transitions (for exponential backoff) |
 | `stateTimestamp` | `number` | Epoch ms of last state write |
 | `schemaVersion` | `number` | Schema version (currently `1`) |
 
@@ -420,7 +420,7 @@ curl $API_URL/status
 curl -X POST $API_URL/toggle
 
 # 6. Wait 15 seconds for the timeout, then call again
-#    Circuit transitions HALF -> CLOSED as requests succeed
+#    Circuit transitions HALF-OPEN -> CLOSED as requests succeed
 curl $API_URL/
 curl $API_URL/
 ```

--- a/examples/layer/template.yaml
+++ b/examples/layer/template.yaml
@@ -173,4 +173,4 @@ Outputs:
       3. GET /node (repeat — failures, then circuit opens with fallback)
       4. GET /node/status (see OPEN state)
       5. POST /node/toggle (makes downstream healthy)
-      6. Wait 10 seconds, then GET /node (HALF -> CLOSED recovery)
+      6. Wait 10 seconds, then GET /node (HALF-OPEN -> CLOSED recovery)

--- a/examples/sam/index.mjs
+++ b/examples/sam/index.mjs
@@ -9,7 +9,7 @@ import { CircuitBreaker } from "circuitbreaker-lambda";
 // "CircuitBreaker state: OPEN" instead of calling the downstream.
 const circuitBreaker = new CircuitBreaker(callDownstream, {
   failureThreshold: 3,   // open after 3 failures
-  successThreshold: 2,   // close after 2 successes in HALF state
+  successThreshold: 2,   // close after 2 successes in HALF-OPEN state
   timeout: 15000,        // try again after 15s
 });
 

--- a/examples/sam/template.yaml
+++ b/examples/sam/template.yaml
@@ -75,4 +75,4 @@ Outputs:
       (makes downstream healthy again)
       6. Wait 15 seconds for the circuit timeout
       7. curl ${ServerlessHttpApi}.execute-api.${AWS::Region}.amazonaws.com/
-      (circuit transitions HALF -> CLOSED as requests succeed)
+      (circuit transitions HALF-OPEN -> CLOSED as requests succeed)

--- a/layer/extension/src/circuit.rs
+++ b/layer/extension/src/circuit.rs
@@ -55,7 +55,7 @@ impl CircuitManager {
                 return CheckResponse {
                     allowed: true,
                     state: state.circuit_state.to_string(),
-                    transition: Some("OPEN -> HALF".to_string()),
+                    transition: Some("OPEN -> HALF-OPEN".to_string()),
                 };
             }
             return CheckResponse {
@@ -85,7 +85,7 @@ impl CircuitManager {
                 state.success_count = 0;
                 state.failure_count = 0;
                 state.consecutive_opens = 0;
-                transition = Some("HALF -> CLOSED".to_string());
+                transition = Some("HALF-OPEN -> CLOSED".to_string());
             }
         }
 
@@ -108,7 +108,7 @@ impl CircuitManager {
         state.last_failure_time = now_ms();
 
         if state.circuit_state == CircuitState::Half {
-            let from = "HALF";
+            let from = "HALF-OPEN";
             self.to_open(&mut state, true);
             transition = Some(format!("{from} -> OPEN"));
         } else if state.failure_count >= self.config.failure_threshold {

--- a/layer/extension/src/types.rs
+++ b/layer/extension/src/types.rs
@@ -8,7 +8,7 @@ pub enum CircuitState {
     Closed,
     #[serde(rename = "OPEN")]
     Open,
-    #[serde(rename = "HALF")]
+    #[serde(rename = "HALF-OPEN", alias = "HALF")]
     Half,
 }
 
@@ -17,7 +17,7 @@ impl std::fmt::Display for CircuitState {
         match self {
             CircuitState::Closed => write!(f, "CLOSED"),
             CircuitState::Open => write!(f, "OPEN"),
-            CircuitState::Half => write!(f, "HALF"),
+            CircuitState::Half => write!(f, "HALF-OPEN"),
         }
     }
 }

--- a/layer/extension/src/types.rs
+++ b/layer/extension/src/types.rs
@@ -93,7 +93,7 @@ impl CircuitConfig {
 pub struct CheckResponse {
     pub allowed: bool,
     pub state: String,
-    /// Present when a state transition occurred (e.g., "OPEN -> HALF").
+    /// Present when a state transition occurred (e.g., "OPEN -> HALF-OPEN").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub transition: Option<String>,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "node": ">=20.0.0"
       },
       "optionalDependencies": {
-        "@middy/core": ">=4.0.0"
+        "@middy/core": ">=4.0.0 <7.0.0"
       }
     },
     "node_modules/@aws-crypto/sha256-browser": {

--- a/src/__tests__/circuitbreaker.test.ts
+++ b/src/__tests__/circuitbreaker.test.ts
@@ -118,7 +118,7 @@ describe("CircuitBreaker", () => {
       expect(request).not.toHaveBeenCalled();
     });
 
-    it("should transition from OPEN to HALF when timeout expires", async () => {
+    it("should transition from OPEN to HALF-OPEN when timeout expires", async () => {
       await provider.saveState("test-circuit", {
         ...createInitialState(),
         circuitState: "OPEN",
@@ -132,10 +132,10 @@ describe("CircuitBreaker", () => {
       expect(request).toHaveBeenCalledOnce();
     });
 
-    it("should transition from HALF to CLOSED after success threshold", async () => {
+    it("should transition from HALF-OPEN to CLOSED after success threshold", async () => {
       await provider.saveState("test-circuit", {
         ...createInitialState(),
-        circuitState: "HALF",
+        circuitState: "HALF-OPEN",
         successCount: 1,
       });
       const request = vi.fn().mockResolvedValue("ok");
@@ -150,10 +150,10 @@ describe("CircuitBreaker", () => {
       expect(state?.consecutiveOpens).toBe(0);
     });
 
-    it("should immediately reopen on single failure in HALF state", async () => {
+    it("should immediately reopen on single failure in HALF-OPEN state", async () => {
       await provider.saveState("test-circuit", {
         ...createInitialState(),
-        circuitState: "HALF",
+        circuitState: "HALF-OPEN",
       });
       const request = vi.fn().mockRejectedValue(new Error("fail"));
       const cb = createBreaker(request);
@@ -187,7 +187,7 @@ describe("CircuitBreaker", () => {
       expect(allowed).toBe(false);
     });
 
-    it("should transition OPEN->HALF and return true when timeout expired", async () => {
+    it("should transition OPEN->HALF-OPEN and return true when timeout expired", async () => {
       await provider.saveState("test-circuit", {
         ...createInitialState(),
         circuitState: "OPEN",
@@ -200,10 +200,10 @@ describe("CircuitBreaker", () => {
       expect(allowed).toBe(true);
     });
 
-    it("should record success and transition HALF->CLOSED", async () => {
+    it("should record success and transition HALF-OPEN->CLOSED", async () => {
       await provider.saveState("test-circuit", {
         ...createInitialState(),
-        circuitState: "HALF",
+        circuitState: "HALF-OPEN",
         successCount: 1,
       });
       const cb = createBreaker(null, { successThreshold: 2 });
@@ -215,10 +215,10 @@ describe("CircuitBreaker", () => {
       expect(state?.circuitState).toBe("CLOSED");
     });
 
-    it("should record failure and transition HALF->OPEN", async () => {
+    it("should record failure and transition HALF-OPEN->OPEN", async () => {
       await provider.saveState("test-circuit", {
         ...createInitialState(),
-        circuitState: "HALF",
+        circuitState: "HALF-OPEN",
       });
       const cb = createBreaker(null);
 
@@ -287,10 +287,10 @@ describe("CircuitBreaker", () => {
       expect(state?.nextAttempt).toBeLessThanOrEqual(before + 5100);
     });
 
-    it("should double timeout on consecutive reopens from HALF", async () => {
+    it("should double timeout on consecutive reopens from HALF-OPEN", async () => {
       await provider.saveState("test-circuit", {
         ...createInitialState(),
-        circuitState: "HALF",
+        circuitState: "HALF-OPEN",
         consecutiveOpens: 0,
       });
       const request = vi.fn().mockRejectedValue(new Error("fail"));
@@ -327,7 +327,7 @@ describe("CircuitBreaker", () => {
     it("should cap timeout at maxTimeout", async () => {
       await provider.saveState("test-circuit", {
         ...createInitialState(),
-        circuitState: "HALF",
+        circuitState: "HALF-OPEN",
         consecutiveOpens: 10,
       });
       const request = vi.fn().mockRejectedValue(new Error("fail"));
@@ -346,7 +346,7 @@ describe("CircuitBreaker", () => {
     it("should reset consecutiveOpens when circuit closes", async () => {
       await provider.saveState("test-circuit", {
         ...createInitialState(),
-        circuitState: "HALF",
+        circuitState: "HALF-OPEN",
         successCount: 1,
         consecutiveOpens: 3,
       });

--- a/src/__tests__/dynamodb-provider.test.ts
+++ b/src/__tests__/dynamodb-provider.test.ts
@@ -73,6 +73,26 @@ describe("DynamoDBProvider", () => {
       expect(result?.schemaVersion).toBe(1);
     });
 
+    it("should normalize legacy HALF state to HALF-OPEN", async () => {
+      ddbMock.on(GetCommand).resolves({
+        Item: {
+          id: "my-circuit",
+          circuitState: "HALF",
+          failureCount: 0,
+          successCount: 1,
+          nextAttempt: 0,
+          lastFailureTime: 0,
+          consecutiveOpens: 0,
+          stateTimestamp: 1234567890,
+          schemaVersion: 1,
+        },
+      });
+
+      const result = await provider.getState("my-circuit");
+
+      expect(result?.circuitState).toBe("HALF-OPEN");
+    });
+
     it("should wrap DynamoDB errors with context", async () => {
       ddbMock.on(GetCommand).rejects(new Error("access denied"));
 

--- a/src/__tests__/middy.test.ts
+++ b/src/__tests__/middy.test.ts
@@ -37,10 +37,10 @@ describe("circuitBreakerMiddleware", () => {
     expect(result).toBeUndefined();
   });
 
-  it("should record success and transition HALF toward CLOSED", async () => {
+  it("should record success and transition HALF-OPEN toward CLOSED", async () => {
     await provider.saveState("test-circuit", {
       ...createInitialState(),
-      circuitState: "HALF",
+      circuitState: "HALF-OPEN",
       successCount: 0,
     });
     const mw = createMiddleware({ successThreshold: 2 });

--- a/src/__tests__/middy.test.ts
+++ b/src/__tests__/middy.test.ts
@@ -51,7 +51,7 @@ describe("circuitBreakerMiddleware", () => {
 
     const state = await provider.getState("test-circuit");
     expect(state?.successCount).toBe(1);
-    expect(state?.circuitState).toBe("HALF");
+    expect(state?.circuitState).toBe("HALF-OPEN");
   });
 
   it("should record failure and rethrow on onError", async () => {

--- a/src/dynamodb-provider.ts
+++ b/src/dynamodb-provider.ts
@@ -25,8 +25,10 @@ export class DynamoDBProvider implements StateProvider {
         }),
       );
       if (!result.Item) return undefined;
+      const rawState = result.Item.circuitState;
       return {
-        circuitState: result.Item.circuitState ?? "CLOSED",
+        // Normalize legacy "HALF" written by older versions
+        circuitState: (rawState === "HALF" ? "HALF-OPEN" : rawState) ?? "CLOSED",
         failureCount: result.Item.failureCount ?? 0,
         successCount: result.Item.successCount ?? 0,
         nextAttempt: result.Item.nextAttempt ?? 0,

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,7 +99,7 @@ export class CircuitBreaker {
 
   /**
    * Check whether the circuit allows a request.
-   * Loads state from the provider and transitions OPEN->HALF if timeout expired.
+   * Loads state from the provider and transitions OPEN->HALF-OPEN if timeout expired.
    * Returns true if the request should proceed, false if the circuit is OPEN.
    */
   async check(): Promise<boolean> {
@@ -217,7 +217,7 @@ export class CircuitBreaker {
   }
 
   /**
-   * Exponential backoff only applies to consecutive HALF->OPEN transitions.
+   * Exponential backoff only applies to consecutive HALF-OPEN->OPEN transitions.
    * CLOSED->OPEN always uses the base timeout since the downstream service
    * may have recovered between independent failure episodes.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ export class CircuitBreaker {
           action: "transition",
           circuitId: this.circuitId,
           from: "OPEN",
-          to: "HALF",
+          to: "HALF-OPEN",
         });
         this.toHalf();
         await this.persistState();
@@ -136,13 +136,13 @@ export class CircuitBreaker {
     if (!this.stateLoaded) {
       throw new Error("CircuitBreaker: recordSuccess() called without a preceding check()");
     }
-    if (this.state.circuitState === "HALF") {
+    if (this.state.circuitState === "HALF-OPEN") {
       this.state.successCount++;
       if (this.state.successCount >= this.successThreshold) {
         log("info", {
           action: "transition",
           circuitId: this.circuitId,
-          from: "HALF",
+          from: "HALF-OPEN",
           to: "CLOSED",
         });
         this.toClosed();
@@ -160,11 +160,11 @@ export class CircuitBreaker {
     this.state.failureCount++;
     this.state.lastFailureTime = Date.now();
 
-    if (this.state.circuitState === "HALF") {
+    if (this.state.circuitState === "HALF-OPEN") {
       log("info", {
         action: "transition",
         circuitId: this.circuitId,
-        from: "HALF",
+        from: "HALF-OPEN",
         to: "OPEN",
         consecutiveOpens: this.state.consecutiveOpens + 1,
       });
@@ -189,7 +189,9 @@ export class CircuitBreaker {
     try {
       const record = await this.provider.getState(this.circuitId);
       if (record) {
-        this.state = { ...record };
+        // Normalize legacy "HALF" state written by older versions
+        const circuitState = (record.circuitState as string) === "HALF" ? "HALF-OPEN" : record.circuitState;
+        this.state = { ...record, circuitState };
       }
     } catch (err) {
       log("warn", { action: "getState", circuitId: this.circuitId, error: String(err) });
@@ -220,7 +222,7 @@ export class CircuitBreaker {
    * may have recovered between independent failure episodes.
    */
   private toOpen(): void {
-    const wasHalf = this.state.circuitState === "HALF";
+    const wasHalf = this.state.circuitState === "HALF-OPEN";
     this.state.circuitState = "OPEN";
 
     if (wasHalf) {
@@ -244,7 +246,7 @@ export class CircuitBreaker {
   }
 
   private toHalf(): void {
-    this.state.circuitState = "HALF";
+    this.state.circuitState = "HALF-OPEN";
     this.state.successCount = 0;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type CircuitState = "CLOSED" | "OPEN" | "HALF";
+export type CircuitState = "CLOSED" | "OPEN" | "HALF-OPEN";
 
 export interface CircuitBreakerState {
   circuitState: CircuitState;


### PR DESCRIPTION
## Summary

Renames the `HALF` circuit state to `HALF-OPEN` throughout — the canonical terminology from Nygard's *Release It!* and Fowler's circuit breaker pattern.

### Changes
- `CircuitState` type: `"HALF"` → `"HALF-OPEN"`
- DynamoDB now stores `"HALF-OPEN"` as the state value
- Rust extension: `#[serde(rename = "HALF-OPEN", alias = "HALF")]` for backwards compatibility
- Node.js DynamoDB provider normalizes legacy `"HALF"` → `"HALF-OPEN"` on read
- All logs, transition messages, JSDoc, comments, README, and examples updated
- New test: verifies legacy `HALF` normalization in the DynamoDB provider

### Backwards compatibility
- Old `"HALF"` records in DynamoDB are normalized to `"HALF-OPEN"` on read by both the npm package and the Rust extension
- No migration needed — existing DynamoDB tables work without changes

## Test plan
- [x] 58 unit tests passing (57 + 1 new legacy normalization test)
- [x] Rust compiles clean
- [x] Integration tested on AWS: all 24 lifecycle assertions pass
- [x] Dedicated HALF-OPEN verification: 9/9 pass — confirmed `HALF-OPEN` is written to DynamoDB by all three patterns (npm, layer+Node.js, layer+Python)
- [x] Legacy `HALF` records correctly normalized on read