### PR TITLE
fix: correct eslint ignore pattern and remove excess IAM permissions

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -8,6 +8,6 @@ export default tseslint.config(
     },
   },
   {
-    ignores: ["dist/", "example/", "*.config.*"],
+    ignores: ["dist/", "examples/", "*.config.*"],
   },
 );

--- a/examples/layer/template.yaml
+++ b/examples/layer/template.yaml
@@ -96,7 +96,6 @@ Resources:
               Action:
                 - dynamodb:GetItem
                 - dynamodb:UpdateItem
-                - dynamodb:PutItem
               Resource: !GetAtt CircuitBreakerTable.Arn
       Events:
         Call:
@@ -134,7 +133,6 @@ Resources:
               Action:
                 - dynamodb:GetItem
                 - dynamodb:UpdateItem
-                - dynamodb:PutItem
               Resource: !GetAtt CircuitBreakerTable.Arn
       Events:
         Call:

--- a/examples/sam/template.yaml
+++ b/examples/sam/template.yaml
@@ -25,7 +25,6 @@ Resources:
               Action:
                 - dynamodb:GetItem
                 - dynamodb:UpdateItem
-                - dynamodb:PutItem
               Resource: !GetAtt CircuitBreakerTable.Arn
       Events:
         Call:


### PR DESCRIPTION
## Summary

- Fix ESLint ignore pattern typo: `"example/"` → `"examples/"` (correct plural directory name)
- Remove unnecessary `dynamodb:PutItem` from SAM example IAM policies — the DynamoDB provider only uses `GetItem` and `UpdateItem` (UpdateCommand with SET does upserts), matching the README's least-privilege documentation

## Test plan

- [ ] `npm run lint` passes
- [ ] `sam validate` on both example templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)