### PR TITLE
ci: update workflow to use main branch instead of master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Updates the CI workflow to trigger on the `main` branch instead of `master` following the recent branch rename.

## Changes

- Updated `.github/workflows/ci.yml` to use `main` as the target branch for push and pull request triggers